### PR TITLE
feat: prevent "bounce" effects overflow behavior on IOS

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -22,6 +22,7 @@
       bottom: 0;
       overflow-x: hidden;
       overflow-y: auto;
+      overscroll-behavior-y: none;
       background: red;
     }
 


### PR DESCRIPTION
Added `overscroll-behavior-y: none;` prevents the browser's default overscroll behavior on the y-axis (no "bounce" effects on IOS) , see: https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior